### PR TITLE
Added support for using environment variables to set options

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ A Prometheus exporter for your tesla car
 
 ### Options
 
-- --version Show version number [boolean]
-- --token TESLA API Token [required]
-- --port Used HTTP port for metrics export [default: 9898]
-- --interval Scraping interval in seconds [default: 120]
-- --vin VIN of the car to be monitored. If not provided the fist one will be used.
-- --debug Debug mode
-- --help Show help
+Some options can be set as environment variables instead of command line arguments.
+
+- `--version` Show version number [boolean]
+- `--token` TESLA API Token [required] (environment variable name: `TESLA_EXPORTER_TOKEN`)
+- `--port` Used HTTP port for metrics export [default: 9898] (environment variable name: `TESLA_EXPORTER_PORT`)
+- `--interval` Scraping interval in seconds [default: 120] (environment variable name: `TESLA_EXPORTER_INTERVAL`)
+- `--vin` VIN of the car to be monitored. If not provided the fist one will be used. (environment variable name: `TESLA_EXPORTER_VIN`)
+- `--debug` Debug mode (environment variable name: `TESLA_EXPORTER_DEBUG`)
+- `--help` Show help

--- a/src/tesla-prometheus-exporter.ts
+++ b/src/tesla-prometheus-exporter.ts
@@ -27,11 +27,28 @@ const options: ClientOptions = yargs
       description: 'Tesla account API token',
       type: 'string',
       demandOption: true,
+      default: process.env.TESLA_EXPORTER_TOKEN,
     },
-    port: { description: 'Used HTTP port', default: DEFAULT_HTTP_PORT },
-    interval: { alias: 'i', description: 'Scraping interval in seconds', default: 120 },
-    vin: { description: 'VIN of the car to be monitored', type: 'string' },
-    debug: { alias: 'd', description: 'Debug mode', boolean: true, default: false },
+    port: {
+      description: 'Used HTTP port',
+      default: parseInt(process.env.TESLA_EXPORTER_PORT) || DEFAULT_HTTP_PORT,
+    },
+    interval: {
+      alias: 'i',
+      description: 'Scraping interval in seconds',
+      default: parseInt(process.env.TESLA_EXPORTER_INTERVAL) || 120,
+    },
+    vin: {
+      description: 'VIN of the car to be monitored',
+      type: 'string',
+      default: process.env.TESLA_EXPORTER_VIN,
+    },
+    debug: {
+      alias: 'd',
+      description: 'Debug mode',
+      boolean: true,
+      default: /true/i.test(process.env.TESLA_EXPORTER_DEBUG),
+    },
   })
   .help().argv;
 
@@ -313,6 +330,9 @@ async function run() {
   const server = expr.listen(options.port);
   console.log(`Exporter listening on port ${options.port}...(press CTRL+c to interrupt)`);
   try {
+    if (!options.token) {
+      throw new Error('Token is required');
+    }
     const api = new TeslaAPI(options.token);
     const vehicles = await api.vehicles();
     // get the selected vehicle or the first one!


### PR DESCRIPTION
The purpose of the PR is to allow setting options via environment variables rather than command line arguments.

Arguments will take precedent over environment variables.

Also updated README.